### PR TITLE
Feature/36-null-value-support

### DIFF
--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartConfigurationPage.xaml
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartConfigurationPage.xaml
@@ -39,6 +39,16 @@
                                 <Frame Grid.Column="1"
                                        Margin="5,3"
                                        Padding="10,3"
+                                       BackgroundColor="Blue"
+                                       IsVisible="{Binding IsDynamic}"
+                                       VerticalOptions="Center">
+                                    <Label FontSize="Small"
+                                           Text="DYNAMIC"
+                                           TextColor="White" />
+                                </Frame>
+                                <Frame Grid.Column="1"
+                                       Margin="5,3"
+                                       Padding="10,3"
                                        BackgroundColor="Red"
                                        IsVisible="{Binding IsSeries}"
                                        VerticalOptions="Center">

--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
@@ -21,7 +21,14 @@ namespace Microcharts.Samples.Forms
             
         }
 
+        private bool Running = true;
         public ExampleChartItem ExampleChartItem { get; }
+
+        protected override void OnDisappearing()
+        {
+            Running = false;
+            base.OnDisappearing();
+        }
 
         protected override void OnAppearing()
         {
@@ -30,6 +37,69 @@ namespace Microcharts.Samples.Forms
             chartView.Chart = ExampleChartItem.Chart;
             if(!chartView.Chart.IsAnimating)
                 chartView.Chart.AnimateAsync(true).ConfigureAwait(false);
+
+            if (ExampleChartItem.IsDynamic && (chartView.Chart as LineChart) != null )
+            {
+                Random r = new Random((int)DateTime.Now.Ticks);
+                LineChart lc = (LineChart)chartView.Chart;
+
+
+#if false
+/*
+                DelayTimer timer = Timer.Create() as DelayTimer;
+
+                int minTicks = (int)(1000 * TimeSpan.TicksPerMillisecond);
+                int maxTicks = (int)(2000 * TimeSpan.TicksPerMillisecond);
+
+                timer.Start(new TimeSpan(r.Next(minTicks, maxTicks)), () =>
+                {
+                    chartView.Chart = null;
+                    foreach (var s in lc.Series)
+                    {
+                        DateTime label = DateTime.Now;
+                        var value = r.Next(0, 100);
+                        var entry = new ChartEntry(value) { ValueLabel = value.ToString(), Label = label.ToString("mm:ss") };
+                        var entries = s.Entries.ToList();
+                        entries.Add(entry);
+
+                        if (entries.Count > 15) entries.RemoveAt(0);
+
+                        s.Entries = entries;
+                    }
+
+                    chartView.Chart = lc;
+                    return Running;
+                });
+*/
+
+#else
+                int ticks = (int)(1000 * TimeSpan.TicksPerMillisecond);
+
+                foreach ( var s in lc.Series )
+                {
+                    DelayTimer timer = Timer.Create() as DelayTimer;
+
+
+                    timer.Start(new TimeSpan(ticks), () =>
+                    {
+                        chartView.Chart = null;
+
+                        DateTime label = DateTime.Now;
+                        var value = r.Next(0, 100);
+                        var entry = new ChartEntry(value) { ValueLabel = value.ToString(), Label = label.ToString("mm:ss") };
+                        var entries = s.Entries.ToList();
+                        entries.Add(entry);
+
+                        s.Entries = entries;
+                        chartView.Chart = lc;
+
+                        return Running;
+                    });
+
+                    ticks += (int)(1000 * TimeSpan.TicksPerMillisecond);
+                }
+#endif
+            }
         }
     }
 }

--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
@@ -35,7 +35,7 @@ namespace Microcharts.Samples.Forms
             Random r = new Random((int)DateTime.Now.Ticks);
             LineChart lc = (LineChart)chartView.Chart;
 
-            int ticks = (int)(1000 * TimeSpan.TicksPerMillisecond);
+            int ticks = (int)(1100 * TimeSpan.TicksPerMillisecond);
 
             var series = lc.Series;
             
@@ -47,36 +47,41 @@ namespace Microcharts.Samples.Forms
                 DelayTimer timer = Timer.Create() as DelayTimer;
                 timer.Start(new TimeSpan(ticks), () =>
                 {
-                    var label = DateTime.Now.ToString("mm:ss");
-
-                    foreach (var curSeries in series)
+                    Device.InvokeOnMainThreadAsync(() =>
                     {
-                        var entries = curSeries.Entries.ToList();
-                        if (s == curSeries)
-                        {
-                            var value = r.Next(rMin, rMax);
-                            var entry = new ChartEntry(value) { ValueLabel = value.ToString(), Label = label };
-                            entries.Add(entry);
-                            if( entries.Count() > count*1.5 ) entries.RemoveAt(0);
-                        }
-                        else
-                        {
-                            var entry = new ChartEntry(null) { ValueLabel = null, Label = label };
-                            entries.Add(entry);
-                            if (entries.Count() > count * 1.5) entries.RemoveAt(0);
-                        }
-                        curSeries.Entries = entries;
-                    }
+                        var label = DateTime.Now.ToString("mm:ss");
 
-                    if (!lc.IsAnimating)
-                    {
-                        lc.IsAnimated = false;
-                        lc.Series = series;
-                        chartView.InvalidateSurface();
-                    }
+                        foreach (var curSeries in series)
+                        {
+                            var entries = curSeries.Entries.ToList();
+                            if (s == curSeries)
+                            {
+                                var value = r.Next(rMin, rMax);
+                                var entry = new ChartEntry(value) { ValueLabel = value.ToString(), Label = label };
+                                entries.Add(entry);
+                                if (entries.Count() > count * 1.5) entries.RemoveAt(0);
+                            }
+                            else
+                            {
+                                var entry = new ChartEntry(null) { ValueLabel = null, Label = label };
+                                entries.Add(entry);
+                                if (entries.Count() > count * 1.5) entries.RemoveAt(0);
+                            }
+                            curSeries.Entries = entries;
+                        }
+
+                        if (!lc.IsAnimating)
+                        {
+                            lc.IsAnimated = false;
+                            lc.Series = series;
+                            chartView.InvalidateSurface();
+                        }
+                    }).ContinueWith(t => {
+                        if (t.IsFaulted) Console.WriteLine(t.Exception);
+                    });
                     return Running;
                 });
-                ticks += (int)(1000 * TimeSpan.TicksPerMillisecond);
+                ticks += (int)(1100 * TimeSpan.TicksPerMillisecond);
             }
         }
 

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -1313,7 +1313,6 @@ namespace Microcharts.Samples
                     LabelTextSize = 14,
                     ValueLabelTextSize = 14,
                     SerieLabelTextSize = 42,
-                    LineAreaAlpha = 0,
                     ShowYAxisLines = true,
                     ShowYAxisText = true,
                     YAxisPosition = Position.Left,

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -1299,6 +1299,45 @@ namespace Microcharts.Samples
                 },
             };
 
+
+
+            yield return new ExampleChartItem()
+            {
+                ExampleName = "Dynamic Line Chart",
+                ExampleDescription = "Line Chart with updating series",
+                ExampleChartType = ExampleChartType.Dynamic,
+                Chart = new LineChart
+                {
+                    LabelOrientation = Orientation.Vertical,
+                    ValueLabelOrientation = Orientation.Horizontal,
+                    LabelTextSize = 14,
+                    ValueLabelTextSize = 14,
+                    SerieLabelTextSize = 42,
+                    LineAreaAlpha = 0,
+                    ShowYAxisLines = true,
+                    ShowYAxisText = true,
+                    YAxisPosition = Position.Left,
+                    LegendOption = SeriesLegendOption.Bottom,
+
+                    Series = new List<ChartSerie>()
+                    {
+                        new ChartSerie()
+                        {
+                            Name = "Sensor 1",
+                            Color = SKColor.Parse("#2c3e50"),
+                            Entries = GenerateTimeSeriesEntry(r),
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "Sensor 2",
+                            Color = SKColor.Parse("#77d065"),
+                            Entries = GenerateTimeSeriesEntry(r),
+                        }
+                    }
+                }
+            };
+
+
             yield break;
         }
 
@@ -1397,6 +1436,25 @@ namespace Microcharts.Samples
             };
 
             yield break;
+        }
+
+        private static IEnumerable<ChartEntry> GenerateTimeSeriesEntry( Random r )
+        {
+            List<ChartEntry> entries = new List<ChartEntry>();
+
+            DateTime end = DateTime.Now;
+            DateTime label = end.AddSeconds(-10);
+
+            var value = r.Next(0, 100);
+            do
+            {
+                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = label.ToString("mm:ss") });
+                value = r.Next(0, 100);
+                label = label.AddSeconds(1);
+            }
+            while (label <= end);
+
+            return entries;
         }
 
         private static IEnumerable<ChartEntry> GenerateSeriesEntry(Random r, int labelNumber = 3, bool withLabel = true)

--- a/Sources/Microcharts.Samples/ExampleChartItem.cs
+++ b/Sources/Microcharts.Samples/ExampleChartItem.cs
@@ -9,11 +9,13 @@ namespace Microcharts.Samples
         public ExampleChartType ExampleChartType { get; set; }
         public bool IsSimple => ExampleChartType == ExampleChartType.Simple;
         public bool IsSeries => ExampleChartType == ExampleChartType.Series;
+        public bool IsDynamic => ExampleChartType == ExampleChartType.Dynamic;
     }
 
     public enum ExampleChartType
     {
         Simple,
-        Series
+        Series,
+        Dynamic
     }
 }

--- a/Sources/Microcharts/ChartEntry.cs
+++ b/Sources/Microcharts/ChartEntry.cs
@@ -16,7 +16,7 @@ namespace Microcharts
         /// Initializes a new instance of the <see cref="T:Microcharts.ChartEntry"/> class.
         /// </summary>
         /// <param name="value">The entry value.</param>
-        public ChartEntry(float value)
+        public ChartEntry(float? value)
         {
             this.Value = value;
         }
@@ -29,7 +29,7 @@ namespace Microcharts
         /// Gets the value.
         /// </summary>
         /// <value>The value.</value>
-        public float Value { get; }
+        public float? Value { get; }
 
         /// <summary>
         /// Gets or sets the caption label.

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -253,8 +253,9 @@ namespace Microcharts
         /// <param name="itemX"></param>
         protected virtual void DrawValueLabel(SKCanvas canvas, Dictionary<ChartEntry, SKRect> valueLabelSizes, float headerWithLegendHeight, SKSize itemSize, SKSize barSize, ChartEntry entry, float barX, float barY, float itemX, float origin)
         {
-            if (!string.IsNullOrEmpty(entry?.ValueLabel))
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, YPositionBehavior.UpToElementHeight, barSize, new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), headerWithLegendHeight - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+            string label = entry?.ValueLabel;
+            if (!string.IsNullOrEmpty(label))
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, YPositionBehavior.UpToElementHeight, barSize, new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), headerWithLegendHeight - Margin), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], label, ValueLabelTextSize, Typeface);
         }
 
         /// <summary>

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -206,6 +206,8 @@ namespace Microcharts
                     for (int serieIndex = 0; serieIndex < nbSeries; serieIndex++)
                     {
                         ChartSerie serie = Series.ElementAt(serieIndex);
+                        if (i >= serie.Entries.Count()) continue;
+
                         ChartEntry entry = serie.Entries.ElementAt(i);
                         float value = entry?.Value ?? 0;
                         float marge = serieIndex < nbSeries ? Margin / 2 : 0;

--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -202,10 +202,10 @@ namespace Microcharts
 
                 if (InternalMinValue == null)
                 {
-                    return Math.Min(0, entries.Min(x => x.Value));
+                    return Math.Min(0, entries.Where( x=>x.Value.HasValue).Min(x => x.Value.Value));
                 }
 
-                return Math.Min(InternalMinValue.Value, entries.Min(x => x.Value));
+                return Math.Min(InternalMinValue.Value, entries.Where(x => x.Value.HasValue).Min(x => x.Value.Value));
             }
 
             set => InternalMinValue = value;
@@ -227,10 +227,10 @@ namespace Microcharts
 
                 if (InternalMaxValue == null)
                 {
-                    return Math.Max(0, entries.Max(x => x.Value));
+                    return Math.Max(0, entries.Where( x=>x.Value.HasValue ).Max(x => x.Value.Value));
                 }
 
-                return Math.Max(InternalMaxValue.Value, entries.Max(x => x.Value));
+                return Math.Max(InternalMaxValue.Value, entries.Where(x => x.Value.HasValue).Max(x => x.Value.Value));
             }
 
             set => InternalMaxValue = value;

--- a/Sources/Microcharts/Charts/DonutChart.cs
+++ b/Sources/Microcharts/Charts/DonutChart.cs
@@ -58,14 +58,16 @@ namespace Microcharts
 
                     canvas.Translate(DrawableChartArea.Left + DrawableChartArea.Width / 2, height / 2);
 
-                    var sumValue = Entries.Sum(x => Math.Abs(x.Value));
+                    var sumValue = Entries.Where( x => x.Value.HasValue ).Sum(x => Math.Abs(x.Value.Value));
                     var radius = (Math.Min(DrawableChartArea.Width, DrawableChartArea.Height) - (2 * Margin)) / 2;
                     var start = 0.0f;
 
                     for (int i = 0; i < Entries.Count(); i++)
                     {
                         var entry = Entries.ElementAt(i);
-                        var end = start + ((Math.Abs(entry.Value) / sumValue) * AnimationProgress);
+                        if (!entry.Value.HasValue) continue;
+
+                        var end = start + ((Math.Abs(entry.Value.Value) / sumValue) * AnimationProgress);
 
                         // Sector
                         var path = RadialHelpers.CreateSectorPath(start, end, radius, radius * HoleRadius);
@@ -88,7 +90,7 @@ namespace Microcharts
         private void DrawCaption(SKCanvas canvas, int width, int height)
         {
             var isGraphCentered = GraphPosition == GraphPosition.Center;
-            var sumValue = Entries.Sum(x => Math.Abs(x.Value));
+            var sumValue = Entries.Where( x => x.Value.HasValue ).Sum(x => Math.Abs(x.Value.Value));
 
             switch (LabelMode)
             {
@@ -107,7 +109,7 @@ namespace Microcharts
 
         private void DrawCaptionLeftAndRight(SKCanvas canvas, int width, int height, bool isGraphCentered)
         {
-            var sumValue = Entries.Sum(x => Math.Abs(x.Value));
+            var sumValue = Entries.Where(x => x.Value.HasValue).Sum(x => Math.Abs(x.Value.Value));
             var rightValues = new List<ChartEntry>();
             var leftValues = new List<ChartEntry>();
             int i = 0;
@@ -116,14 +118,18 @@ namespace Microcharts
             while (i < Entries.Count() && (current < sumValue / 2))
             {
                 var entry = Entries.ElementAt(i);
+                if (!entry.Value.HasValue) continue;
+
                 rightValues.Add(entry);
-                current += Math.Abs(entry.Value);
+                current += Math.Abs(entry.Value.Value);
                 i++;
             }
 
             while (i < Entries.Count())
             {
                 var entry = Entries.ElementAt(i);
+                if (!entry.Value.HasValue) continue;
+
                 leftValues.Add(entry);
                 i++;
             }

--- a/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
+++ b/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
@@ -179,9 +179,10 @@ namespace Microcharts
             for (int i = 0; i < Entries.Count(); i++)
             {
                 var entry = Entries.ElementAt(i);
-                var value = entry.Value;
+                if (!entry.Value.HasValue) continue;
 
-                result.Add(MeasureHelper.CalculatePoint(Margin, AnimationProgress, MaxValue, ValueRange, value, i, itemSize, origin, headerHeight, originX));
+                var value = entry.Value;
+                result.Add(MeasureHelper.CalculatePoint(Margin, AnimationProgress, MaxValue, ValueRange, value.Value, i, itemSize, origin, headerHeight, originX));
             }
 
             return result.ToArray();

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -98,6 +98,11 @@ namespace Microcharts
                     for (int i = 0; i < pps.Value.Count; i++)
                     {
                         var entry = entries[i];
+                        if (!entry.Value.HasValue)
+                        {
+                            continue;
+                        }
+
                         var point = pps.Value.ElementAt(i);
                         canvas.DrawPoint(point, pps.Key.Color ?? entry.Color, PointSize, PointMode);
                     }
@@ -119,13 +124,18 @@ namespace Microcharts
                     for (int i = 0; i < pps.Value.Count; i++)
                     {
                         var entry = entries[i];
-                        if (!string.IsNullOrEmpty(entry.ValueLabel))
+                        string label = entry.ValueLabel;
+                        if (!string.IsNullOrEmpty(label))
                         {
                           var drawedPoint = pps.Value.ElementAt(i);
                           SKPoint point;
                           YPositionBehavior yPositionBehavior = YPositionBehavior.None;
 
-                          if (!valueLabelSizes.ContainsKey(entry)) continue;
+                            if (!valueLabelSizes.ContainsKey(entry))
+                            {
+                                continue;
+                            }
+
                           var valueLabelSize = valueLabelSizes[entry];
                           if (valueLabelOption == ValueLabelOption.TopOfElement)
                           {
@@ -144,7 +154,10 @@ namespace Microcharts
 
                           }
 
-                          DrawHelper.DrawLabel(canvas, ValueLabelOrientation, yPositionBehavior, itemSize, point, entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSize, entry.ValueLabel, ValueLabelTextSize, Typeface);
+                          DrawHelper.DrawLabel(canvas, ValueLabelOrientation, yPositionBehavior, itemSize, point, entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSize, label, ValueLabelTextSize, Typeface);
+                        } else
+                        {
+                            continue;
                         }
                     }
                 }
@@ -172,15 +185,31 @@ namespace Microcharts
 
                         var path = new SKPath();
                         path.MoveTo(points.First());
-                        var last = (LineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
+
+
+                        var entries = s.Entries;
+                        var lineMode = LineMode.Straight; // LineMode;
+                        var last = (lineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
                         for (int i = 0; i < last; i++)
                         {
-                            if (LineMode == LineMode.Spline)
+                            if (!entries.ElementAt(i).Value.HasValue) continue;
+                            if (lineMode == LineMode.Spline)
                             {
-                                var cubicInfo = CalculateCubicInfo(points, i, itemSize);
+                                int next = i + 1;
+                                while (next < last && !entries.ElementAt(next).Value.HasValue)
+                                {
+                                    next++;
+                                }
+
+                                if (next == last && !entries.ElementAt(next).Value.HasValue)
+                                {
+                                    break;
+                                }
+
+                                var cubicInfo = CalculateCubicInfo(points, i, next, itemSize);
                                 path.CubicTo(cubicInfo.control, cubicInfo.nextControl, cubicInfo.nextPoint);
                             }
-                            else if (LineMode == LineMode.Straight)
+                            else if (lineMode == LineMode.Straight)
                             {
                                 path.LineTo(points[i]);
                             }
@@ -213,21 +242,40 @@ namespace Microcharts
                         path.MoveTo(points.First().X, origin);
                         path.LineTo(points.First());
 
-                        var last = (LineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
+                        var entries = serie.Entries;
+                        var lineMode = LineMode.Straight; // LineMode;
+                        var last = (lineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
+                        SKPoint lastPoint = points.First();
                         for (int i = 0; i < last; i++)
                         {
-                            if (LineMode == LineMode.Spline)
+                            if (!entries.ElementAt(i).Value.HasValue) continue;
+
+                            if (lineMode == LineMode.Spline)
                             {
-                                var cubicInfo = CalculateCubicInfo(points, i, itemSize);
+                                int next = i + 1;
+                                while (next < last && !entries.ElementAt(next).Value.HasValue)
+                                {
+                                    next++;
+                                }
+
+                                if (next == last && !entries.ElementAt(next).Value.HasValue)
+                                {
+                                    lastPoint = points[i];
+                                    break;
+                                }
+
+                                var cubicInfo = CalculateCubicInfo(points, i, next, itemSize);
                                 path.CubicTo(cubicInfo.control, cubicInfo.nextControl, cubicInfo.nextPoint);
+                                lastPoint = cubicInfo.nextPoint;
                             }
-                            else if (LineMode == LineMode.Straight)
+                            else if (lineMode == LineMode.Straight)
                             {
                                 path.LineTo(points[i]);
+                                lastPoint = points[i];
                             }
                         }
 
-                        path.LineTo(points.Last().X, origin);
+                        path.LineTo(lastPoint.X, origin);
                         path.Close();
                         canvas.DrawPath(path, paint);
                     }
@@ -256,10 +304,10 @@ namespace Microcharts
             //Area is draw on the OnDrawContentEnd
         }
 
-        private (SKPoint control, SKPoint nextPoint, SKPoint nextControl) CalculateCubicInfo(SKPoint[] points, int i, SKSize itemSize)
+        private (SKPoint control, SKPoint nextPoint, SKPoint nextControl) CalculateCubicInfo(SKPoint[] points, int i, int next, SKSize itemSize)
         {
             var point = points[i];
-            var nextPoint = points[i + 1];
+            var nextPoint = points[next];
             var controlOffset = new SKPoint(itemSize.Width * 0.8f, 0);
             var currentControl = point + controlOffset;
             var nextControl = nextPoint - controlOffset;

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -184,15 +184,22 @@ namespace Microcharts
                                 paint.Shader = shader;
 
                         var path = new SKPath();
-                        path.MoveTo(points.First());
+                        //path.MoveTo(points.First());
 
-
+                        var isFirst = true;
                         var entries = s.Entries;
                         var lineMode = LineMode.Straight; // LineMode;
                         var last = (lineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
                         for (int i = 0; i < last; i++)
                         {
                             if (!entries.ElementAt(i).Value.HasValue) continue;
+                            if (isFirst)
+                            {
+                                path.MoveTo(points[i]);
+                                isFirst = false;
+                            }
+
+
                             if (lineMode == LineMode.Spline)
                             {
                                 int next = i + 1;
@@ -239,9 +246,7 @@ namespace Microcharts
 
                         var path = new SKPath();
 
-                        path.MoveTo(points.First().X, origin);
-                        path.LineTo(points.First());
-
+                        var isFirst = true;
                         var entries = serie.Entries;
                         var lineMode = LineMode.Straight; // LineMode;
                         var last = (lineMode == LineMode.Spline) ? points.Length - 1 : points.Length;
@@ -249,6 +254,13 @@ namespace Microcharts
                         for (int i = 0; i < last; i++)
                         {
                             if (!entries.ElementAt(i).Value.HasValue) continue;
+
+                            if( isFirst )
+                            {
+                                path.MoveTo(points[i].X, origin);
+                                path.LineTo(points[i]);
+                                isFirst = false;
+                            }
 
                             if (lineMode == LineMode.Spline)
                             {

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -124,6 +124,8 @@ namespace Microcharts
                           var drawedPoint = pps.Value.ElementAt(i);
                           SKPoint point;
                           YPositionBehavior yPositionBehavior = YPositionBehavior.None;
+
+                          if (!valueLabelSizes.ContainsKey(entry)) continue;
                           var valueLabelSize = valueLabelSizes[entry];
                           if (valueLabelOption == ValueLabelOption.TopOfElement)
                           {

--- a/Sources/Microcharts/Charts/PointChart.cs
+++ b/Sources/Microcharts/Charts/PointChart.cs
@@ -49,16 +49,17 @@ namespace Microcharts
         /// <inheritdoc />
         protected override void DrawValueLabel(SKCanvas canvas, Dictionary<ChartEntry, SKRect> valueLabelSizes, float headerWithLegendHeight, SKSize itemSize, SKSize barSize, ChartEntry entry, float barX, float barY, float itemX, float origin)
         {
-            if (string.IsNullOrEmpty(entry?.ValueLabel))
+            string label = entry?.ValueLabel;
+            if (string.IsNullOrEmpty(label))
                 return;
 
             var drawedPoint = new SKPoint(barX - (itemSize.Width / 2) + (barSize.Width / 2), barY);
             if (ValueLabelOption == ValueLabelOption.TopOfChart)
                 base.DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
             else if (ValueLabelOption == ValueLabelOption.TopOfElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y - (PointSize / 2) - (Margin / 2)), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementHeight : YPositionBehavior.None, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y - (PointSize / 2) - (Margin / 2)), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], label, ValueLabelTextSize, Typeface);
             else if (ValueLabelOption == ValueLabelOption.OverElement)
-                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], entry.ValueLabel, ValueLabelTextSize, Typeface);
+                DrawHelper.DrawLabel(canvas, ValueLabelOrientation, ValueLabelOrientation == Orientation.Vertical ? YPositionBehavior.UpToElementMiddle : YPositionBehavior.DownToElementMiddle, barSize, new SKPoint(drawedPoint.X, drawedPoint.Y), entry.ValueLabelColor.WithAlpha((byte)(255 * AnimationProgress)), valueLabelSizes[entry], label, ValueLabelTextSize, Typeface);
         }
 
         /// <inheritdoc />

--- a/Sources/Microcharts/Charts/RadarChart.cs
+++ b/Sources/Microcharts/Charts/RadarChart.cs
@@ -52,9 +52,9 @@ namespace Microcharts
         /// <value>The size of the point.</value>
         public float PointSize { get; set; } = 14;
 
-        private float AbsoluteMinimum => Entries.Select(x => x.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Min(x => Math.Abs(x));
+        private float AbsoluteMinimum => Entries.Where( x=>x.Value.HasValue).Select(x => x.Value.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Min(x => Math.Abs(x));
 
-        private float AbsoluteMaximum => Entries.Select(x => x.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Max(x => Math.Abs(x));
+        private float AbsoluteMaximum => Entries.Where(x => x.Value.HasValue).Select(x => x.Value.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Max(x => Math.Abs(x));
 
         /// <inheritdoc />
         protected override float ValueRange => AbsoluteMaximum - AbsoluteMinimum;
@@ -101,9 +101,10 @@ namespace Microcharts
                 var rangeAngle = (float)((Math.PI * 2) / total);
                 var startAngle = (float)Math.PI;
 
+                //FIXME: Handle Null Values
                 var nextEntry = Entries.First();
                 var nextAngle = startAngle;
-                var nextPoint = GetPoint(nextEntry.Value * AnimationProgress, center, nextAngle, radius);
+                var nextPoint = GetPoint(nextEntry.Value.Value * AnimationProgress, center, nextAngle, radius);
 
                 DrawBorder(canvas, center, radius);
 
@@ -117,10 +118,11 @@ namespace Microcharts
                         var entry = nextEntry;
                         var point = nextPoint;
 
+                        //FIXME: Handle Null Values
                         var nextIndex = (i + 1) % total;
                         nextAngle = startAngle + (rangeAngle * nextIndex);
                         nextEntry = Entries.ElementAt(nextIndex);
-                        nextPoint = GetPoint(nextEntry.Value * AnimationProgress, center, nextAngle, radius);
+                        nextPoint = GetPoint(nextEntry.Value.Value * AnimationProgress, center, nextAngle, radius);
 
                         canvas.Save();
                         canvas.ClipPath(clip);
@@ -148,7 +150,8 @@ namespace Microcharts
                             IsAntialias = true,
                         })
                         {
-                            var amount = Math.Abs(entry.Value - AbsoluteMinimum) / ValueRange;
+                            //FIXME: Handle Null Values
+                            var amount = Math.Abs(entry.Value.Value - AbsoluteMinimum) / ValueRange;
                             canvas.DrawCircle(center.X, center.Y, radius * amount, paint);
                         }
 

--- a/Sources/Microcharts/Helpers/MeasureHelper.cs
+++ b/Sources/Microcharts/Helpers/MeasureHelper.cs
@@ -77,8 +77,8 @@ namespace Microcharts
                 var yAxisWidth = width;
 
                 var enumerable = entries.ToList(); // to avoid double enumeration
-                var minValue = enumerable.Min(e => e.Value);
-                var maxValue = enumerable.Max(e => e.Value);
+                var minValue = enumerable.Where(e=>e.Value.HasValue).Min(e => e.Value.Value);
+                var maxValue = enumerable.Where(e => e.Value.HasValue).Max(e => e.Value.Value);
                 if(minValue == maxValue)
                 {
                     if (minValue >= 0)


### PR DESCRIPTION
I have modified the charts to support null values, and I added some test data to verify the behavior. There should be null value support for Line Charts (Straight, Spline, and Area), Bar Charts, Point Charts, Pie Charts, Radial Gauges, and Radar Charts.

Charts tested:
- [x] Bar
- [x] Point
- [x] Line
- [x] Donut
- [x] Radar

Platform tested :
- [ ] Android
- [x] iOS
- [ ] MacOS
- [ ] Windows

Fix:
- #36 
- #279 

Visuals:
<img width="564" alt="Screen Shot 2021-08-17 at 5 57 04 PM" src="https://user-images.githubusercontent.com/1433852/129811496-2582e98a-60e9-4c39-b3e4-b95837ffe3d6.png">
<img width="564" alt="Screen Shot 2021-08-17 at 5 56 56 PM" src="https://user-images.githubusercontent.com/1433852/129811498-39f5a0b9-9df7-4069-8321-824f68f80aee.png">
<img width="564" alt="Screen Shot 2021-08-17 at 5 56 38 PM" src="https://user-images.githubusercontent.com/1433852/129811503-88c70e9b-3d33-4b72-a41c-020979ef7b33.png">
<img width="564" alt="Screen Shot 2021-08-17 at 5 56 24 PM" src="https://user-images.githubusercontent.com/1433852/129811504-423e3d35-e185-46d9-b2d0-a4dc988ac23d.png">
<img width="564" alt="Screen Shot 2021-08-17 at 5 55 37 PM" src="https://user-images.githubusercontent.com/1433852/129811506-7130e142-bbde-4f35-9bed-b587bc5ca787.png">
<img width="564" alt="Screen Shot 2021-08-17 at 5 55 01 PM" src="https://user-images.githubusercontent.com/1433852/129811508-4171fb1d-f6fe-462b-8131-b883045bfe47.png">
