### PR TITLE
#288 Animation event if kicked and activity is not more active chartv…

### DIFF
--- a/Sources/Microcharts.Droid/ChartView.cs
+++ b/Sources/Microcharts.Droid/ChartView.cs
@@ -1,4 +1,4 @@
-﻿namespace Microcharts.Droid
+namespace Microcharts.Droid
 {
     using Android.Content;
     using SkiaSharp.Views.Android;
@@ -60,7 +60,7 @@
 
                     if (this.chart != null)
                     {
-                        this.handler = this.chart.ObserveInvalidate(this, (view) => view.Invalidate());
+                        this.handler = this.chart.ObserveInvalidate(this, (view) => { try { view.Invalidate(); } catch (ObjectDisposedException) { } });
                     }
                 }
             }


### PR DESCRIPTION
Because of the Animation delay affect, if the activity is destroyed, Chartview is disposed and trying to access the same raise the exception of objectdisposed and lead to crash of the app itself. 