### PR TITLE
Feature/290-max-value-perf-fixes

### DIFF
--- a/Sources/Microcharts.Forms/ChartView.cs
+++ b/Sources/Microcharts.Forms/ChartView.cs
@@ -6,6 +6,7 @@ namespace Microcharts.Forms
     using Xamarin.Forms;
     using SkiaSharp.Views.Forms;
     using SkiaSharp;
+    using System;
 
     public class ChartView : SKCanvasView
     {
@@ -16,6 +17,8 @@ namespace Microcharts.Forms
             this.BackgroundColor = Color.Transparent;
             this.PaintSurface += OnPaintCanvas;
         }
+
+        public event EventHandler<SKPaintSurfaceEventArgs> ChartPainted;
 
         #endregion
 
@@ -74,6 +77,8 @@ namespace Microcharts.Forms
             {
                 e.Surface.Canvas.Clear(SKColors.Transparent);
             }
+
+            ChartPainted?.Invoke(sender, e);
         }
 
         #endregion

--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
@@ -29,13 +29,13 @@ namespace Microcharts.Samples.Forms
             Running = false;
             base.OnDisappearing();
         }
-
+        bool IsDrawing = false;
         protected void GenerateDynamicData()
         {
             Random r = new Random((int)DateTime.Now.Ticks);
             LineChart lc = (LineChart)chartView.Chart;
 
-            int ticks = (int)(1100 * TimeSpan.TicksPerMillisecond);
+            int ticks = (int)(250 * TimeSpan.TicksPerMillisecond);
 
             var series = lc.Series;
             
@@ -83,14 +83,18 @@ namespace Microcharts.Samples.Forms
                         {
                             lc.IsAnimated = false;
                             lc.Series = series;
-                            chartView.InvalidateSurface();
+                            if (!IsDrawing)
+                            {
+                                IsDrawing = true;
+                                chartView.InvalidateSurface();
+                            }
                         }
                     }).ContinueWith(t => {
                         if (t.IsFaulted) Console.WriteLine(t.Exception);
                     });
                     return Running;
                 });
-                ticks += (int)(1100 * TimeSpan.TicksPerMillisecond);
+                ticks += (int)(250 * TimeSpan.TicksPerMillisecond);
             }
         }
 
@@ -99,7 +103,12 @@ namespace Microcharts.Samples.Forms
             base.OnAppearing();
 
             chartView.Chart = ExampleChartItem.Chart;
-            if(!chartView.Chart.IsAnimating)
+            chartView.ChartPainted += (sender, args) =>
+            {
+                IsDrawing = false;
+            };
+
+            if (!chartView.Chart.IsAnimating)
                 chartView.Chart.AnimateAsync(true).ConfigureAwait(false);
 
             if (ExampleChartItem.IsDynamic && (chartView.Chart as LineChart) != null )

--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
@@ -51,23 +51,32 @@ namespace Microcharts.Samples.Forms
                     {
                         var label = DateTime.Now.ToString("mm:ss");
 
+                        int idx = 0;
                         foreach (var curSeries in series)
                         {
                             var entries = curSeries.Entries.ToList();
+                            bool addLabel = (entries.Count % 100) == 0;
+
                             if (s == curSeries)
                             {
-                                var value = r.Next(rMin, rMax);
-                                var entry = new ChartEntry(value) { ValueLabel = value.ToString(), Label = label };
-                                entries.Add(entry);
+                                var entry = Data.GenerateTimeSeriesEntry(r, idx, 1);
+                                if (!addLabel) entry.First().Label = null;
+
+                                entries.AddRange(entry);
+
                                 if (entries.Count() > count * 1.5) entries.RemoveAt(0);
                             }
                             else
                             {
                                 var entry = new ChartEntry(null) { ValueLabel = null, Label = label };
+                                if (!addLabel) entry.Label = null;
+
                                 entries.Add(entry);
                                 if (entries.Count() > count * 1.5) entries.RemoveAt(0);
                             }
+                            
                             curSeries.Entries = entries;
+                            idx++;
                         }
 
                         if (!lc.IsAnimating)

--- a/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
+++ b/Sources/Microcharts.Samples.Forms/Microcharts.Samples.Forms/ChartPage.xaml.cs
@@ -55,7 +55,7 @@ namespace Microcharts.Samples.Forms
                         foreach (var curSeries in series)
                         {
                             var entries = curSeries.Entries.ToList();
-                            bool addLabel = (entries.Count % 100) == 0;
+                            bool addLabel = (entries.Count % 1000) == 0;
 
                             if (s == curSeries)
                             {

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -239,7 +239,7 @@ namespace Microcharts.Samples
         {
             return new[]
             {
-                new ChartEntry(212)
+                new ChartEntry(112)
                 {
                     Label = "UWP",
                     ValueLabel = "112",

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -1317,12 +1317,15 @@ namespace Microcharts.Samples
                     LabelOrientation = Orientation.Vertical,
                     ValueLabelOrientation = Orientation.Horizontal,
                     LabelTextSize = 14,
+                    LineMode = LineMode.Straight,
+                    PointMode = PointMode.None,
                     ValueLabelTextSize = 14,
                     SerieLabelTextSize = 42,
+                    ValueLabelOption = ValueLabelOption.None,
                     ShowYAxisLines = true,
                     ShowYAxisText = true,
                     MaxValue = 150,
-                    MinValue = -50,
+                    MinValue = -150,
                     YAxisPosition = Position.Left,
                     LegendOption = SeriesLegendOption.Bottom,
 
@@ -1332,14 +1335,21 @@ namespace Microcharts.Samples
                         {
                             Name = "Sensor 1",
                             Color = SKColor.Parse("#2c3e50"),
-                            Entries = GenerateTimeSeriesEntry(r),
+                            Entries = GenerateTimeSeriesEntry(r, 0, 1000),
                         },
                         new ChartSerie()
                         {
                             Name = "Sensor 2",
                             Color = SKColor.Parse("#77d065"),
-                            Entries = GenerateTimeSeriesEntry(r),
+                            Entries = GenerateTimeSeriesEntry(r, 1, 1000),
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "Sensor 3",
+                            Color = SKColor.Parse("#b455b6"),
+                            Entries = GenerateTimeSeriesEntry(r, 2, 1000)
                         }
+
                     }
                 }
             };
@@ -1445,25 +1455,36 @@ namespace Microcharts.Samples
             yield break;
         }
 
-        private static IEnumerable<ChartEntry> GenerateTimeSeriesEntry( Random r, bool withNulls = true)
+        public static IEnumerable<ChartEntry> GenerateTimeSeriesEntry( Random r, int idx, int seconds, bool withNulls = true)
         {
             List<ChartEntry> entries = new List<ChartEntry>();
 
-            Console.WriteLine("Generating Data");
-            DateTime end = DateTime.Now;
-            DateTime label = end.AddSeconds(-1000);
 
-            int? value = r.Next(0, 100);
+            DateTime end = DateTime.Now;
+            DateTime label = end.AddSeconds(-seconds);
+            DateTime baseTime = DateTime.Today;
+
+            float amp = 100.0f;
+            float ampScale = 0.001f + (idx*0.0005f);
+            float valScale = 0.05f + (idx*0.01f);
+            int phase = (idx * 33333);
+            double valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
+            double ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
+            float? value = (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) *amp));
+
+            int count = 0;
             do
             {
                 if (withNulls && (value.Value % 10) == 0) value = null;
-                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = label.ToString("mm:ss") });
-                value = r.Next(0, 100);
+                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = count % 100 == 0 ? label.ToString("mm:ss") : null });
+                valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
+                ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
+                value = (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) * amp));
                 label = label.AddSeconds(1);
+                count++;
             }
             while (label <= end);
 
-            Console.WriteLine("Data Generated");
             return entries;
         }
 

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -1321,6 +1321,8 @@ namespace Microcharts.Samples
                     SerieLabelTextSize = 42,
                     ShowYAxisLines = true,
                     ShowYAxisText = true,
+                    MaxValue = 150,
+                    MinValue = -50,
                     YAxisPosition = Position.Left,
                     LegendOption = SeriesLegendOption.Bottom,
 
@@ -1447,8 +1449,9 @@ namespace Microcharts.Samples
         {
             List<ChartEntry> entries = new List<ChartEntry>();
 
+            Console.WriteLine("Generating Data");
             DateTime end = DateTime.Now;
-            DateTime label = end.AddSeconds(-30);
+            DateTime label = end.AddSeconds(-1000);
 
             int? value = r.Next(0, 100);
             do
@@ -1460,6 +1463,7 @@ namespace Microcharts.Samples
             }
             while (label <= end);
 
+            Console.WriteLine("Data Generated");
             return entries;
         }
 

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -242,25 +242,25 @@ namespace Microcharts.Samples
                 new ChartEntry(212)
                 {
                     Label = "UWP",
-                    ValueLabel = "212",
+                    ValueLabel = "112",
                     Color = SKColor.Parse("#2c3e50"),
                 },
-                new ChartEntry(248)
+                new ChartEntry(648)
                 {
                     Label = "Android",
-                    ValueLabel = "248",
+                    ValueLabel = "648",
                     Color = SKColor.Parse("#77d065"),
                 },
                 new ChartEntry(null)
                 {
                     Label = "React",
-                    ValueLabel = null,
+                    ValueLabel = "",
                     Color = SKColor.Parse("#db3498"),
                 },
-                new ChartEntry(128)
+                new ChartEntry(428)
                 {
                     Label = "iOS",
-                    ValueLabel = "128",
+                    ValueLabel = "428",
                     Color = SKColor.Parse("#b455b6"),
                 },
                 new ChartEntry(514)
@@ -1315,12 +1315,19 @@ namespace Microcharts.Samples
                 Chart = new LineChart
                 {
                     LabelOrientation = Orientation.Vertical,
-                    ValueLabelOrientation = Orientation.Horizontal,
+                    ValueLabelOrientation = Orientation.Vertical,
                     LabelTextSize = 14,
+                    LineMode = LineMode.Straight,
+                    PointMode = PointMode.None,
+                    LineAreaAlpha = 0,
+                    PointAreaAlpha = 0,
                     ValueLabelTextSize = 14,
                     SerieLabelTextSize = 42,
+                    ValueLabelOption = ValueLabelOption.None,
                     ShowYAxisLines = true,
                     ShowYAxisText = true,
+                    MaxValue = 150,
+                    MinValue = -150,
                     YAxisPosition = Position.Left,
                     LegendOption = SeriesLegendOption.Bottom,
 
@@ -1328,15 +1335,33 @@ namespace Microcharts.Samples
                     {
                         new ChartSerie()
                         {
-                            Name = "Sensor 1",
-                            Color = SKColor.Parse("#2c3e50"),
-                            Entries = GenerateTimeSeriesEntry(r),
+                            Name = "S1",
+                            Color = Data.Colors[0],
+                            Entries = GenerateTimeSeriesEntry(r, 0, 10000),
                         },
                         new ChartSerie()
                         {
-                            Name = "Sensor 2",
-                            Color = SKColor.Parse("#77d065"),
-                            Entries = GenerateTimeSeriesEntry(r),
+                            Name = "S2",
+                            Color = Data.Colors[1],
+                            Entries = GenerateTimeSeriesEntry(r, 1, 10000),
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "S3",
+                            Color = Data.Colors[2],
+                            Entries = GenerateTimeSeriesEntry(r, 2, 10000)
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "S4",
+                            Color = Data.Colors[3],
+                            Entries = GenerateTimeSeriesEntry(r, 3, 10000)
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "S5",
+                            Color = Data.Colors[4],
+                            Entries = GenerateTimeSeriesEntry(r, 4, 10000)
                         }
                     }
                 }
@@ -1443,20 +1468,33 @@ namespace Microcharts.Samples
             yield break;
         }
 
-        private static IEnumerable<ChartEntry> GenerateTimeSeriesEntry( Random r, bool withNulls = true)
+        public static IEnumerable<ChartEntry> GenerateTimeSeriesEntry( Random r, int idx, int seconds, bool withNulls = true)
         {
             List<ChartEntry> entries = new List<ChartEntry>();
 
-            DateTime end = DateTime.Now;
-            DateTime label = end.AddSeconds(-30);
 
-            int? value = r.Next(0, 100);
+            DateTime end = DateTime.Now;
+            DateTime label = end.AddSeconds(-seconds);
+            DateTime baseTime = DateTime.Today;
+
+            float amp = 25.0f;
+            float ampScale = 0.001f + (idx*0.0005f);
+            float valScale = 0.05f + (idx*0.01f);
+            int phase = (idx * 33333);
+            double valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
+            double ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
+            float valueShift = (amp * 0.75f * (idx-2));
+            float? value = valueShift + (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) *amp));
+            int count = 0;
             do
             {
                 if (withNulls && (value.Value % 10) == 0) value = null;
-                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = label.ToString("mm:ss") });
-                value = r.Next(0, 100);
+                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = count % 1000 == 0 ? label.ToString("mm:ss") : null });
+                valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
+                ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
+                value = valueShift + (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) * amp));
                 label = label.AddSeconds(1);
+                count++;
             }
             while (label <= end);
 

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -1315,10 +1315,12 @@ namespace Microcharts.Samples
                 Chart = new LineChart
                 {
                     LabelOrientation = Orientation.Vertical,
-                    ValueLabelOrientation = Orientation.Horizontal,
+                    ValueLabelOrientation = Orientation.Vertical,
                     LabelTextSize = 14,
                     LineMode = LineMode.Straight,
                     PointMode = PointMode.None,
+                    LineAreaAlpha = 0,
+                    PointAreaAlpha = 0,
                     ValueLabelTextSize = 14,
                     SerieLabelTextSize = 42,
                     ValueLabelOption = ValueLabelOption.None,
@@ -1333,23 +1335,34 @@ namespace Microcharts.Samples
                     {
                         new ChartSerie()
                         {
-                            Name = "Sensor 1",
-                            Color = SKColor.Parse("#2c3e50"),
-                            Entries = GenerateTimeSeriesEntry(r, 0, 1000),
+                            Name = "S1",
+                            Color = Data.Colors[0],
+                            Entries = GenerateTimeSeriesEntry(r, 0, 10000),
                         },
                         new ChartSerie()
                         {
-                            Name = "Sensor 2",
-                            Color = SKColor.Parse("#77d065"),
-                            Entries = GenerateTimeSeriesEntry(r, 1, 1000),
+                            Name = "S2",
+                            Color = Data.Colors[1],
+                            Entries = GenerateTimeSeriesEntry(r, 1, 10000),
                         },
                         new ChartSerie()
                         {
-                            Name = "Sensor 3",
-                            Color = SKColor.Parse("#b455b6"),
-                            Entries = GenerateTimeSeriesEntry(r, 2, 1000)
+                            Name = "S3",
+                            Color = Data.Colors[2],
+                            Entries = GenerateTimeSeriesEntry(r, 2, 10000)
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "S4",
+                            Color = Data.Colors[3],
+                            Entries = GenerateTimeSeriesEntry(r, 3, 10000)
+                        },
+                        new ChartSerie()
+                        {
+                            Name = "S5",
+                            Color = Data.Colors[4],
+                            Entries = GenerateTimeSeriesEntry(r, 4, 10000)
                         }
-
                     }
                 }
             };
@@ -1464,22 +1477,22 @@ namespace Microcharts.Samples
             DateTime label = end.AddSeconds(-seconds);
             DateTime baseTime = DateTime.Today;
 
-            float amp = 100.0f;
+            float amp = 25.0f;
             float ampScale = 0.001f + (idx*0.0005f);
             float valScale = 0.05f + (idx*0.01f);
             int phase = (idx * 33333);
             double valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
             double ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
-            float? value = (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) *amp));
-
+            float valueShift = (amp * 0.75f * (idx-2));
+            float? value = valueShift + (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) *amp));
             int count = 0;
             do
             {
                 if (withNulls && (value.Value % 10) == 0) value = null;
-                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = count % 100 == 0 ? label.ToString("mm:ss") : null });
+                entries.Add(new ChartEntry(value) { ValueLabel = value.ToString(), Label = count % 1000 == 0 ? label.ToString("mm:ss") : null });
                 valOffset = ((label - baseTime).TotalSeconds + phase) * valScale;
                 ampOffset = ((label - baseTime).TotalSeconds + phase) * ampScale;
-                value = (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) * amp));
+                value = valueShift + (float)(Math.Sin(valOffset) * (Math.Cos(ampOffset) * amp));
                 label = label.AddSeconds(1);
                 count++;
             }

--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -245,7 +245,7 @@ namespace Microcharts.Samples
                     ValueLabel = "112",
                     Color = SKColor.Parse("#2c3e50"),
                 },
-                new ChartEntry(248)
+                new ChartEntry(648)
                 {
                     Label = "Android",
                     ValueLabel = "648",
@@ -254,10 +254,10 @@ namespace Microcharts.Samples
                 new ChartEntry(null)
                 {
                     Label = "React",
-                    ValueLabel = "214",
+                    ValueLabel = "",
                     Color = SKColor.Parse("#db3498"),
                 },
-                new ChartEntry(128)
+                new ChartEntry(428)
                 {
                     Label = "iOS",
                     ValueLabel = "428",
@@ -266,7 +266,7 @@ namespace Microcharts.Samples
                 new ChartEntry(514)
                 {
                     Label = "Forms",
-                    ValueLabel = "214",
+                    ValueLabel = "514",
                     Color = SKColor.Parse("#3498db"),
                 }
             };

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -170,7 +170,10 @@ namespace Microcharts
             if (Series != null && entries != null)
             {
                 //Caching the min/max values for performance
-                bool fixedRange = InternalMaxValue != null || InternalMinValue != null;
+                bool fixedRange = InternalMaxValue.HasValue || InternalMinValue.HasValue;
+
+                //Ideally we'd use the internal values here, but the drawing does not crop to the bounds
+                //So the min and min cannot be set less than the actual min/max of the values
                 float maxValue = MaxValue;
                 float minValue = MinValue;
 

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -169,10 +169,12 @@ namespace Microcharts
         {
             if (Series != null && entries != null)
             {
+                //Caching the min/max values for performance
                 bool fixedRange = InternalMaxValue != null || InternalMinValue != null;
                 float maxValue = MaxValue;
                 float minValue = MinValue;
 
+                //This function might change the min/max value
                 width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, fixedRange, ref maxValue, ref minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 float valRange = maxValue - minValue;
 

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -214,26 +214,28 @@ namespace Microcharts
                     for (int i = 0; i < labels.Length; i++)
                     {
                         if (i >= entryCount) break;
-
-                        ChartEntry entry = entries.ElementAt(i);
-                        if (!entry.Value.HasValue) continue;
-
-                        string label = labels[i];
-                        SKRect labelSize = labelSizes[i];
-
                         var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin)) + yAxisXShift;
 
-                        float value = entry?.Value ?? 0;
-                        float marge = serieIndex < nbSeries ? Margin / 2 : 0;
-                        float totalBarMarge = serieIndex * Margin / 2;
-                        float barX = itemX + serieIndex * barSize.Width + totalBarMarge;
-                        float barY = headerWithLegendHeight + ((1 - AnimationProgress) * (origin - headerWithLegendHeight) + (((maxValue - value) / valRange) * itemSize.Height) * AnimationProgress);
+                        ChartEntry entry = entries.ElementAt(i);
+                        if (entry != null && entry.Value.HasValue)
+                        {
+                            float value = entry.Value.Value;
+                            float marge = serieIndex < nbSeries ? Margin / 2 : 0;
+                            float totalBarMarge = serieIndex * Margin / 2;
+                            float barX = itemX + serieIndex * barSize.Width + totalBarMarge;
+                            float barY = headerWithLegendHeight + ((1 - AnimationProgress) * (origin - headerWithLegendHeight) + (((maxValue - value) / valRange) * itemSize.Height) * AnimationProgress);
 
-                        DrawBarArea(canvas, headerWithLegendHeight, itemSize, barSize, serie.Color ?? entry.Color, origin, value, barX, barY);
-                        DrawBar(serie, canvas, headerWithLegendHeight, itemX, itemSize, barSize, origin, barX, barY, serie.Color ?? entry.Color);
-                        DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
+                            DrawBarArea(canvas, headerWithLegendHeight, itemSize, barSize, serie.Color ?? entry.Color, origin, value, barX, barY);
+                            DrawBar(serie, canvas, headerWithLegendHeight, itemX, itemSize, barSize, origin, barX, barY, serie.Color ?? entry.Color);
+                            DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
+                        }
+
+                        string label = labels[i];
                         if (!string.IsNullOrEmpty(label))
+                        {
+                            SKRect labelSize = labelSizes[i];
                             DrawHelper.DrawLabel(canvas, LabelOrientation, YPositionBehavior.None, itemSize, new SKPoint(itemX, height - footerWithLegendHeight + Margin), LabelColor, labelSize, label, LabelTextSize, Typeface);
+                        }
                     }
                 }
 

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -232,6 +232,10 @@ namespace Microcharts
                             DrawBar(serie, canvas, headerWithLegendHeight, itemX, itemSize, barSize, origin, barX, barY, serie.Color ?? entry.Color);
                             DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
                         }
+                        else
+                        {
+                            DrawNullPoint(serie, canvas);
+                        }
 
                         string label = labels[i];
                         if (!string.IsNullOrEmpty(label))
@@ -453,6 +457,13 @@ namespace Microcharts
         /// <param name="barY"></param>
         /// <param name="color"></param>
         protected abstract void DrawBar(ChartSerie serie, SKCanvas canvas, float headerHeight, float itemX, SKSize itemSize, SKSize barSize, float origin, float barX, float barY, SKColor color);
+
+
+        /// <summary>
+        /// Called during the draw cycle when encountering a point with a null value
+        /// </summary>
+        protected virtual void DrawNullPoint(ChartSerie serie, SKCanvas canvas) { }
+        
 
         /// <summary>
         /// Draw bar (or point) area of an entry

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -167,9 +167,14 @@ namespace Microcharts
         /// <param name="height">The height of the chart.</param>
         public override void DrawContent(SKCanvas canvas, int width, int height)
         {
+            Console.WriteLine("DrawContent");
             if (Series != null && entries != null)
             {
-                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, out float yAxisXShift, out List<float> yAxisIntervalLabels);
+                float maxValue = MaxValue;
+                float minValue = MinValue;
+                float valRange = maxValue - minValue;
+
+                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, maxValue, minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 var firstSerie = Series.FirstOrDefault();
                 var labels = firstSerie.Entries.Select(x => x.Label).ToArray();
                 int nbItems = labels.Length;
@@ -190,42 +195,51 @@ namespace Microcharts
                 float headerHeight = CalculateHeaderHeight(valueLabelSizes);
                 var headerWithLegendHeight = headerHeight + (LegendOption == SeriesLegendOption.Top ? legendHeight : 0);
 
+
+
                 var itemSize = CalculateItemSize(nbItems, width, height, footerHeight + headerHeight + legendHeight);
                 var barSize = CalculateBarSize(itemSize, Series.Count());
-                var origin = CalculateYOrigin(itemSize.Height, headerWithLegendHeight);
-                DrawHelper.DrawYAxis(ShowYAxisText, ShowYAxisLines, YAxisPosition, YAxisTextPaint, YAxisLinesPaint, Margin, AnimationProgress, MaxValue, ValueRange, canvas, width, yAxisXShift, yAxisIntervalLabels, headerHeight, itemSize, origin);
+                var origin = CalculateYOrigin(itemSize.Height, headerWithLegendHeight, maxValue, minValue, valRange);
+                DrawHelper.DrawYAxis(ShowYAxisText, ShowYAxisLines, YAxisPosition, YAxisTextPaint, YAxisLinesPaint, Margin, AnimationProgress, maxValue, valRange, canvas, width, yAxisXShift, yAxisIntervalLabels, headerHeight, itemSize, origin);
+                Console.WriteLine("Begin Points");
+
 
                 int nbSeries = series.Count();
-                for (int i = 0; i < labels.Length; i++)
+                for (int serieIndex = 0; serieIndex < nbSeries; serieIndex++)
                 {
-                    string label = labels[i];
-                    SKRect labelSize = labelSizes[i];
+                    ChartSerie serie = Series.ElementAt(serieIndex);
+                    IEnumerable<ChartEntry> entries = serie.Entries;
+                    int entryCount = entries.Count();
 
-                    var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin));
 
-                    for (int serieIndex = 0; serieIndex < nbSeries; serieIndex++)
+                    Console.WriteLine("Drawing Series: " + serieIndex);
+                    for (int i = 0; i < labels.Length; i++)
                     {
-                        ChartSerie serie = Series.ElementAt(serieIndex);
-                        if (i >= serie.Entries.Count()) continue;
+                        if (i >= entryCount) break;
 
-                        ChartEntry entry = serie.Entries.ElementAt(i);
+                        ChartEntry entry = entries.ElementAt(i);
                         if (!entry.Value.HasValue) continue;
+
+                        string label = labels[i];
+                        SKRect labelSize = labelSizes[i];
+
+                        var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin));
 
                         float value = entry?.Value ?? 0;
                         float marge = serieIndex < nbSeries ? Margin / 2 : 0;
                         float totalBarMarge = serieIndex * Margin / 2;
                         float barX = itemX + serieIndex * barSize.Width + totalBarMarge;
-                        float barY = headerWithLegendHeight + ((1 - AnimationProgress) * (origin - headerWithLegendHeight) + (((MaxValue - value) / ValueRange) * itemSize.Height) * AnimationProgress);
+                        float barY = headerWithLegendHeight + ((1 - AnimationProgress) * (origin - headerWithLegendHeight) + (((maxValue - value) / valRange) * itemSize.Height) * AnimationProgress);
 
                         DrawBarArea(canvas, headerWithLegendHeight, itemSize, barSize, serie.Color ?? entry.Color, origin, value, barX, barY);
                         DrawBar(serie, canvas, headerWithLegendHeight, itemX, itemSize, barSize, origin, barX, barY, serie.Color ?? entry.Color);
                         DrawValueLabel(canvas, valueLabelSizes, headerWithLegendHeight, itemSize, barSize, entry, barX, barY, itemX, origin);
+                        if (!string.IsNullOrEmpty(label))
+                            DrawHelper.DrawLabel(canvas, LabelOrientation, YPositionBehavior.None, itemSize, new SKPoint(itemX, height - footerWithLegendHeight + Margin), LabelColor, labelSize, label, LabelTextSize, Typeface);
                     }
-
-                    if(!string.IsNullOrEmpty(label))
-                        DrawHelper.DrawLabel(canvas, LabelOrientation, YPositionBehavior.None, itemSize, new SKPoint(itemX, height - footerWithLegendHeight + Margin), LabelColor, labelSize, label, LabelTextSize, Typeface);
                 }
 
+                Console.WriteLine("Begin Legend");
                 DrawLegend(canvas, seriesSizes, legendHeight, height, width);
                 OnDrawContentEnd(canvas, itemSize, origin, valueLabelSizes);
             }
@@ -382,19 +396,19 @@ namespace Microcharts
             return nbLine * height + nbLine * Margin;
         }
 
-        private float CalculateYOrigin(float itemHeight, float headerHeight)
+        private float CalculateYOrigin(float itemHeight, float headerHeight, float max, float min, float range)
         {
-            if (MaxValue <= 0)
+            if (max <= 0)
             {
                 return headerHeight;
             }
 
-            if (MinValue > 0)
+            if (min > 0)
             {
                 return headerHeight + itemHeight;
             }
 
-            return headerHeight + ((MaxValue / ValueRange) * itemHeight);
+            return headerHeight + ((max / range) * itemHeight);
         }
 
         private Dictionary<ChartEntry, SKRect> MeasureValueLabels()

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -213,6 +213,18 @@ namespace Microcharts
                     IEnumerable<ChartEntry> entries = serie.Entries;
                     int entryCount = entries.Count();
 
+                    for (int i = 0; i < labels.Length; i++)
+                    {
+                        var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin)) + yAxisXShift;
+
+                        string label = labels[i];
+                        if (!string.IsNullOrEmpty(label))
+                        {
+                            SKRect labelSize = labelSizes[i];
+                            DrawHelper.DrawLabel(canvas, LabelOrientation, YPositionBehavior.None, itemSize, new SKPoint(itemX, height - footerWithLegendHeight + Margin), LabelColor, labelSize, label, LabelTextSize, Typeface);
+                        }
+                    }
+
 
                     for (int i = 0; i < labels.Length; i++)
                     {
@@ -235,13 +247,6 @@ namespace Microcharts
                         else
                         {
                             DrawNullPoint(serie, canvas);
-                        }
-
-                        string label = labels[i];
-                        if (!string.IsNullOrEmpty(label))
-                        {
-                            SKRect labelSize = labelSizes[i];
-                            DrawHelper.DrawLabel(canvas, LabelOrientation, YPositionBehavior.None, itemSize, new SKPoint(itemX, height - footerWithLegendHeight + Margin), LabelColor, labelSize, label, LabelTextSize, Typeface);
                         }
                     }
                 }

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -167,7 +167,6 @@ namespace Microcharts
         /// <param name="height">The height of the chart.</param>
         public override void DrawContent(SKCanvas canvas, int width, int height)
         {
-            Console.WriteLine("DrawContent");
             if (Series != null && entries != null)
             {
                 float maxValue = MaxValue;
@@ -195,13 +194,10 @@ namespace Microcharts
                 float headerHeight = CalculateHeaderHeight(valueLabelSizes);
                 var headerWithLegendHeight = headerHeight + (LegendOption == SeriesLegendOption.Top ? legendHeight : 0);
 
-
-
                 var itemSize = CalculateItemSize(nbItems, width, height, footerHeight + headerHeight + legendHeight);
                 var barSize = CalculateBarSize(itemSize, Series.Count());
                 var origin = CalculateYOrigin(itemSize.Height, headerWithLegendHeight, maxValue, minValue, valRange);
                 DrawHelper.DrawYAxis(ShowYAxisText, ShowYAxisLines, YAxisPosition, YAxisTextPaint, YAxisLinesPaint, Margin, AnimationProgress, maxValue, valRange, canvas, width, yAxisXShift, yAxisIntervalLabels, headerHeight, itemSize, origin);
-                Console.WriteLine("Begin Points");
 
 
                 int nbSeries = series.Count();
@@ -212,7 +208,6 @@ namespace Microcharts
                     int entryCount = entries.Count();
 
 
-                    Console.WriteLine("Drawing Series: " + serieIndex);
                     for (int i = 0; i < labels.Length; i++)
                     {
                         if (i >= entryCount) break;
@@ -239,7 +234,6 @@ namespace Microcharts
                     }
                 }
 
-                Console.WriteLine("Begin Legend");
                 DrawLegend(canvas, seriesSizes, legendHeight, height, width);
                 OnDrawContentEnd(canvas, itemSize, origin, valueLabelSizes);
             }

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -169,11 +169,13 @@ namespace Microcharts
         {
             if (Series != null && entries != null)
             {
+                bool fixedRange = InternalMaxValue != null || InternalMinValue != null;
                 float maxValue = MaxValue;
                 float minValue = MinValue;
+
+                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, fixedRange, ref maxValue, ref minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 float valRange = maxValue - minValue;
 
-                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, maxValue, minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 var firstSerie = Series.FirstOrDefault();
                 var labels = firstSerie.Entries.Select(x => x.Label).ToArray();
                 int nbItems = labels.Length;

--- a/Sources/Microcharts/Charts/AxisBasedChart.cs
+++ b/Sources/Microcharts/Charts/AxisBasedChart.cs
@@ -201,7 +201,6 @@ namespace Microcharts
                 var origin = CalculateYOrigin(itemSize.Height, headerWithLegendHeight, maxValue, minValue, valRange);
                 DrawHelper.DrawYAxis(ShowYAxisText, ShowYAxisLines, YAxisPosition, YAxisTextPaint, YAxisLinesPaint, Margin, AnimationProgress, maxValue, valRange, canvas, width, yAxisXShift, yAxisIntervalLabels, headerHeight, itemSize, origin);
 
-
                 int nbSeries = series.Count();
                 for (int serieIndex = 0; serieIndex < nbSeries; serieIndex++)
                 {
@@ -220,7 +219,7 @@ namespace Microcharts
                         string label = labels[i];
                         SKRect labelSize = labelSizes[i];
 
-                        var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin));
+                        var itemX = Margin + (itemSize.Width / 2) + (i * (itemSize.Width + Margin)) + yAxisXShift;
 
                         float value = entry?.Value ?? 0;
                         float marge = serieIndex < nbSeries ? Margin / 2 : 0;

--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -554,6 +554,10 @@ namespace Microcharts
                 {
                     await AnimateAsync(false, cancellation.Token);
                 }
+                else if( !IsAnimated )
+                {
+                    AnimationProgress = 1; //This prevents an extra property change on dynamic data
+                }
                 else
                 {
                     AnimationProgress = 0;
@@ -611,7 +615,7 @@ namespace Microcharts
         /// <typeparam name="T">The 1st type parameter.</typeparam>
         protected bool Set<T>(ref T field, T value, [CallerMemberName] string property = null)
         {
-            if (!EqualityComparer<T>.Equals(field, property))
+            if ((field == null && value != null) || !field.Equals(value))
             {
                 field = value;
                 RaisePropertyChanged(property);

--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -434,7 +434,7 @@ namespace Microcharts
                 case nameof(MaxValue):
                 case nameof(MinValue):
                 case nameof(BackgroundColor):
-                    PlanifyInvalidate();
+                    Invalidate();
                     break;
                 default:
                     break;

--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -615,7 +615,7 @@ namespace Microcharts
         /// <typeparam name="T">The 1st type parameter.</typeparam>
         protected bool Set<T>(ref T field, T value, [CallerMemberName] string property = null)
         {
-            if ((field == null && value != null) || !field.Equals(value))
+            if(!EqualityComparer<T>.Default.Equals(field, value))
             {
                 field = value;
                 RaisePropertyChanged(property);

--- a/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
+++ b/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
@@ -128,7 +128,9 @@ namespace Microcharts
         {
             if (Entries != null)
             {
-                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, Entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, MaxValue, MinValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
+                float maxValue = MaxValue;
+                float minValue = MinValue;
+                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, Entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, false, ref maxValue, ref minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 var labels = Entries.Select(x => x.Label).ToArray();
                 var labelSizes = MeasureHelper.MeasureTexts(labels, LabelTextSize);
                 var footerHeight = MeasureHelper.CalculateFooterHeaderHeight(Margin, LabelTextSize, labelSizes, LabelOrientation);

--- a/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
+++ b/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
@@ -128,7 +128,7 @@ namespace Microcharts
         {
             if (Entries != null)
             {
-                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, Entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, out float yAxisXShift, out List<float> yAxisIntervalLabels);
+                width = MeasureHelper.CalculateYAxis(ShowYAxisText, ShowYAxisLines, Entries, YAxisMaxTicks, YAxisTextPaint, YAxisPosition, width, MaxValue, MinValue, out float yAxisXShift, out List<float> yAxisIntervalLabels);
                 var labels = Entries.Select(x => x.Label).ToArray();
                 var labelSizes = MeasureHelper.MeasureTexts(labels, LabelTextSize);
                 var footerHeight = MeasureHelper.CalculateFooterHeaderHeight(Margin, LabelTextSize, labelSizes, LabelOrientation);

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -74,6 +74,12 @@ namespace Microcharts
             base.DrawContent(canvas, width, height);
         }
 
+        protected override void DrawNullPoint(ChartSerie serie, SKCanvas canvas) {
+            //Some of the drawing algorithms index into pointsPerSerie
+            var point = new SKPoint(float.MinValue, float.MinValue);
+            pointsPerSerie[serie].Add(point);
+        }
+
         /// <inheritdoc/>
         protected override void OnDrawContentEnd(SKCanvas canvas, SKSize itemSize, float origin, Dictionary<ChartEntry, SKRect> valueLabelSizes)
         {

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SkiaSharp;
@@ -78,14 +79,20 @@ namespace Microcharts
         {
             base.OnDrawContentEnd(canvas, itemSize, origin, valueLabelSizes);
 
+            Console.WriteLine("DrawContentEnd");
             foreach (var pps in pointsPerSerie)
             {
                 DrawLineArea(canvas, pps.Key, pps.Value.ToArray(), itemSize, origin);
             }
 
+            Console.WriteLine("DrawSeriesLine");
             DrawSeriesLine(canvas, itemSize);
+            Console.WriteLine("DrawPoints");
             DrawPoints(canvas);
+            Console.WriteLine("DrawValueLabels");
             DrawValueLabels(canvas, itemSize, valueLabelSizes);
+            Console.WriteLine("Done");
+            Console.WriteLine("");
         }
 
         private void DrawPoints(SKCanvas canvas)

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -79,20 +79,14 @@ namespace Microcharts
         {
             base.OnDrawContentEnd(canvas, itemSize, origin, valueLabelSizes);
 
-            Console.WriteLine("DrawContentEnd");
             foreach (var pps in pointsPerSerie)
             {
                 DrawLineArea(canvas, pps.Key, pps.Value.ToArray(), itemSize, origin);
             }
 
-            Console.WriteLine("DrawSeriesLine");
             DrawSeriesLine(canvas, itemSize);
-            Console.WriteLine("DrawPoints");
             DrawPoints(canvas);
-            Console.WriteLine("DrawValueLabels");
             DrawValueLabels(canvas, itemSize, valueLabelSizes);
-            Console.WriteLine("Done");
-            Console.WriteLine("");
         }
 
         private void DrawPoints(SKCanvas canvas)

--- a/Sources/Microcharts/Helpers/MeasureHelper.cs
+++ b/Sources/Microcharts/Helpers/MeasureHelper.cs
@@ -68,7 +68,7 @@ namespace Microcharts
             return result;
         }
 
-        internal static int CalculateYAxis(bool showYAxisText, bool showYAxisLines, IEnumerable<ChartEntry> entries, int yAxisMaxTicks, SKPaint yAxisTextPaint, Position yAxisPosition, int width, out float yAxisXShift, out List<float> yAxisIntervalLabels)
+        internal static int CalculateYAxis(bool showYAxisText, bool showYAxisLines, IEnumerable<ChartEntry> entries, int yAxisMaxTicks, SKPaint yAxisTextPaint, Position yAxisPosition, int width, float maxValue, float minValue, out float yAxisXShift, out List<float> yAxisIntervalLabels)
         {
             yAxisXShift = 0.0f;
             yAxisIntervalLabels = new List<float>();
@@ -76,9 +76,7 @@ namespace Microcharts
             {
                 var yAxisWidth = width;
 
-                var enumerable = entries.ToList(); // to avoid double enumeration
-                var minValue = enumerable.Where(e=>e.Value.HasValue).Min(e => e.Value.Value);
-                var maxValue = enumerable.Where(e => e.Value.HasValue).Max(e => e.Value.Value);
+                //var enumerable = entries.ToList(); // to avoid double enumeration
                 if(minValue == maxValue)
                 {
                     if (minValue >= 0)


### PR DESCRIPTION
I have modified the AxisBasedCharts to rework the main render loop. The main changes are to move the Min,Max, and Range values to the top and store them in local variables. This caches the values of these functions so they are not recalculated each bar/line/point render. I made a few other changes that were related to my changes

Notable Changes: 
- Above mentioned performance changes
- - https://github.com/microcharts-dotnet/Microcharts/blob/e0f1c371287389c2e11b61f6831b892faa0fa49c/Sources/Microcharts/Charts/AxisBasedChart.cs#L177 
- Modified Y Axis drawing so if the developer sets the Min/Max values it does not override them with "nice" values
- - https://github.com/microcharts-dotnet/Microcharts/blob/e0f1c371287389c2e11b61f6831b892faa0fa49c/Sources/Microcharts/Charts/AxisBasedChart.cs#L173 
- - https://github.com/microcharts-dotnet/Microcharts/blob/e0f1c371287389c2e11b61f6831b892faa0fa49c/Sources/Microcharts/Helpers/MeasureHelper.cs#L73
- Fixed Y axis calculations for negative numbers on a line chart
- Added the yAxisShift in the bar/line drawing. For Left Y Axis labels it wasn't taken into account so there wasn't any room
- - Before yAxis Shift:
- - <img width="452" alt="Before" src="https://user-images.githubusercontent.com/1433852/137648001-feac5738-5241-4f5c-84a3-7b6e13b18ac8.png">
- - After yAxis Shift
- - <img width="452" alt="After" src="https://user-images.githubusercontent.com/1433852/137647984-c545ab89-688e-4f39-96fd-caa30d20c80d.png">
- Make sure the NiceMin and NiceMax values are carried into later functions
- Added a Render Completed Event
- - The purpose is to be able to have a loading wheel while its painting; then hide on finish.
- - https://github.com/microcharts-dotnet/Microcharts/blob/e0f1c371287389c2e11b61f6831b892faa0fa49c/Sources/Microcharts.Forms/ChartView.cs#L81
- Fixed an invalid comparison with Property Changed equality testing
- - This was pretty nefarious. I started a review
- - https://github.com/microcharts-dotnet/Microcharts/blob/e0f1c371287389c2e11b61f6831b892faa0fa49c/Sources/Microcharts/Charts/Chart.cs#L618
- Don't double set animation progress when updating a series
- Removed reference to PlanifyInvalidate, this delay was really slow
- Made Dynamic Line chart have way more data

Charts tested:
- [x] Bar
- [x] Point
- [x] Line
- [x] Donut
- [x] Radar

Platform tested :
- [ ] Android
- [x] iOS
- [ ] MacOS
- [ ] Windows

Fix:
- #290 





