### PR TITLE
Fixes microcharts-dotnet/Microcharts#260

### DIFF
--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -516,7 +516,7 @@ namespace Microcharts
 
                 var progress = (float)(watch.Elapsed.TotalSeconds / animationDuration.TotalSeconds);
                 progress = entrance ? Ease.In(progress) : Ease.Out(progress);
-                AnimationProgress = start + (progress * (end - start));
+                AnimationProgress = IsAnimated ? start + (progress * (end - start)) : end;
 
                 var shouldContinue = (entrance && AnimationProgress < 1) || (!entrance && AnimationProgress > 0);
 


### PR DESCRIPTION
#260 During the animation of the chart, the process varies depending on whether IsAnimated is true or false. If IsAnimated is false, the progress will have the end value to finish the animation; otherwise, the progress gets an intepolated value between start and end, as it did before.

