### PR TITLE
bump skiadraw nuget

### DIFF
--- a/Sources/Microcharts.Eto/Microcharts.Eto.csproj
+++ b/Sources/Microcharts.Eto/Microcharts.Eto.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Eto.SkiaDraw" Version="0.1.0" />
+        <PackageReference Include="Eto.SkiaDraw" Version="0.2.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The updated nuget version handles alpha correctly (ref https://github.com/rafntor/Eto.SkiaDraw/commit/6be7feaeaf36a83e9b5a27f232f706cdc937276f)