### PR TITLE
Update GitHub Actions for publishing NuGet packages

### DIFF
--- a/.github/workflows/CI-MacOS.yml
+++ b/.github/workflows/CI-MacOS.yml
@@ -1,4 +1,4 @@
-name: Mac Builds
+name: Publish NuGet packages (Mac)
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -8,43 +8,36 @@ jobs:
   Mac-NuGet-Builds:
     env:
       NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_TOKEN}}
+      DOTNET_NOLOGO: true
 
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build Microcharts.Core
+    - name: Clone source
+      uses: actions/checkout@v3.1.0
+      with:
+        fetch-depth: 0
+
+    - name: Install .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
+    - name: "Restore NuGet packages (Mac)"
+      run: msbuild /t:restore /p:Configuration=Release Sources/Microcharts-mac.slnf /v:diag /bl:mac-build.binlog
+
+    - name: "Publish bin logs as artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: msbuild-binlogs
+        path: '**/*.binlog'
+      if: always()
+
+    - name: "Build and pack Microcharts macOS"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.macOS/Microcharts.macOS.csproj
+
+    - name: Publish packages to nuget.org
       run: |
-        cd Sources/Microcharts
-        msbuild -t:build -restore Microcharts.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Core
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Core.nuspec
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json
-    - name: Build Microcharts.Android
-      run: |
-        cd Sources/Microcharts.Droid
-        msbuild -t:build -restore Microcharts.Droid.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Android
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Android.nuspec
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json
-    - name: Build Microcharts.iOS
-      run: |
-        cd Sources/Microcharts.iOS
-        msbuild -t:build -restore Microcharts.iOS.csproj /p:Configuration=Release
-    - name: Publish Microcharts.iOS
-      run: |
-        cd NuGet
-        nuget pack Microcharts.iOS.nuspec
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json
-    - name: Build Microcharts.Mac
-      run: |
-        cd Sources/Microcharts.macOS
-        msbuild -t:build -restore Microcharts.macOS.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Mac
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Mac.nuspec
+        cd artifacts
         nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-MacOS.yml
+++ b/.github/workflows/CI-MacOS.yml
@@ -40,4 +40,5 @@ jobs:
     - name: Publish packages to nuget.org
       run: |
         cd artifacts
+        ls *.nupkg
         nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -19,7 +19,6 @@ jobs:
 
     - name: Add MSBuild to PATH (Windows)
       uses: microsoft/setup-msbuild@v1.1.3
-      if: matrix.os == 'windows-latest'
 
     - name: Install .NET SDK
       uses: actions/setup-dotnet@v3
@@ -77,4 +76,5 @@ jobs:
     - name: Publish packages to nuget.org
       run: |
         cd artifacts
+        dir *.nupkg
         nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -1,4 +1,4 @@
-name: Windows Builds
+name: Publish NuGet packages (Windows)
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -8,34 +8,73 @@ jobs:
   Windows-nuget-Builds:
     env:
       NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_TOKEN}}
+      DOTNET_NOLOGO: true
 
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build Microcharts.Avalonia
+    - name: Clone source
+      uses: actions/checkout@v3.1.0
+      with:
+        fetch-depth: 0
+
+    - name: Add MSBuild to PATH (Windows)
+      uses: microsoft/setup-msbuild@v1.1.3
+      if: matrix.os == 'windows-latest'
+
+    - name: Install .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          6.0.x
+          7.0.x
+
+    - name: "Restore NuGet packages (Windows)"
+      run: msbuild /t:restore /p:Configuration=Release Sources/Microcharts.sln /v:diag /bl:win-build.binlog
+
+    - name: "Publish bin logs as artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: msbuild-binlogs
+        path: '**/*.binlog'
+      if: always()
+
+    - name: "Build and pack Microcharts"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
+
+    - name: "Build and pack Microcharts Android"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj
+
+    - name: "Build and pack Microcharts Xamarin.Forms"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Forms/Microcharts.Forms.csproj
+
+    - name: "Build and pack Microcharts iOS"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.iOS/Microcharts.iOS.csproj
+
+    - name: "Build and pack Microcharts UWP"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Uwp/Microcharts.Uwp.csproj
+
+    - name: "Build and pack Microcharts Avalonia"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Avalonia/Microcharts.Avalonia.csproj
+
+    - name: "Build and pack Microcharts Eto"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Eto/Microcharts.Eto.csproj
+
+    - name: "Build and pack Microcharts .NET MAUI"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Maui/Microcharts.Maui.csproj
+
+    - name: "Build and pack Microcharts Uno"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Uno/Microcharts.Uno.csproj
+
+    - name: "Build and pack Microcharts Uno WinUI"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Uno.WinUI/Microcharts.Uno.WinUI.csproj
+
+    - name: "Build and pack Microcharts WinUI"
+      run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.WinUI/Microcharts.WinUI.csproj
+
+    - name: "Build and pack Microcharts Meta-package"
+      run: dotnet pack Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj
+
+    - name: Publish packages to nuget.org
       run: |
-        cd Sources/Microcharts.Avalonia
-        msbuild -t:build -restore Microcharts.Avalonia.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Avalonia
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Avalonia.nuspec
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json
-    - name: Build Microcharts.Uwp
-      run: |
-        cd Sources/Microcharts.Uwp
-        msbuild -t:build -restore Microcharts.Uwp.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Uwp
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Uwp.nuspec
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json
-    - name: Build Microcharts.Forms
-      run: |
-        cd Sources/Microcharts.Forms
-        msbuild -t:build -restore Microcharts.Forms.csproj /p:Configuration=Release
-    - name: Publish Microcharts.Forms
-      run: |
-        cd NuGet
-        nuget pack Microcharts.Forms.nuspec
+        cd artifacts
         nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Hi @eman1986 , this PR updates the two GitHub Actions that are for building, packing, and publishing all the various NuGet packages in this repo to make them public on nuget.org.

It's based on a combination of the already-existing CI scripts in this repo, but adapting them to use the build introduced in an earlier PR.

Everything that was previously built & published is still there, plus all the various new packages that have been added over the past several months (.NET MAUI, Uno, and others).

I ran these as a test on my fork and they seemed to work just fine, except of course I couldn't actually publish the packages because only you have a valid nuget.org API key.

* Windows run: https://github.com/Eilon/Microcharts/actions/runs/4824328593/jobs/8593972329
* Mac run: https://github.com/Eilon/Microcharts/actions/runs/4824328346/jobs/8593971674

As part of the final publish step (that fails, because I don't have the key), I have the command list all the NUPKG files that it found, just to make sure it's the right list, and it looks correct:

* Windows NUPKG list:
    ```         Directory: D:\a\Microcharts\Microcharts\artifacts

    Mode                 LastWriteTime         Length Name
    ----                 -------------         ------ ----
    -a---           4/27/2023  9:10 PM           2065 Microcharts.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           5805 Microcharts.Avalonia.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:03 PM          38465 Microcharts.Core.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           5221 Microcharts.Droid.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           4506 Microcharts.Eto.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           5320 Microcharts.Forms.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           4759 Microcharts.iOS.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:08 PM         100999 Microcharts.Maui.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:09 PM           5862 Microcharts.Uno.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:09 PM           5933 Microcharts.Uno.WinUI.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:06 PM           6019 Microcharts.Uwp.1.0.0-preview2.nupkg
    -a---           4/27/2023  9:09 PM           5842 Microcharts.WinUI.1.0.0-preview2.nupkg
    ```
* Mac NUPKG list:
    ```
    Microcharts.macOS.1.0.0-preview2.nupkg
    ```