### PR TITLE
Added Net7.0 target to make UnitTesting easier

### DIFF
--- a/Sources/Microcharts.Maui/Microcharts.Maui.csproj
+++ b/Sources/Microcharts.Maui/Microcharts.Maui.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <!-- iOS, Android, MacCatalyst -->
-        <TargetFrameworks>net7.0-ios;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks>net7.0;net7.0-ios;net7.0-android;net7.0-maccatalyst</TargetFrameworks>
         <TargetFrameworks Condition="$(IsWindows)">$(TargetFrameworks);net7.0-windows10.0.19041</TargetFrameworks>
         <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
         <PackagingPlatform Condition="$(TargetFramework.Contains('-windows'))">net7.0-windows</PackagingPlatform>


### PR DESCRIPTION
This should fix #340 and enable people to write unit-tests for their apps that reference Microcharts. 